### PR TITLE
Perf improvements for sub-expres and index-exprs

### DIFF
--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -38,8 +38,8 @@ def index(index):
     return {"type": "index", "value": index, "children": []}
 
 
-def index_expression(left, right):
-    return {"type": "index_expression", 'children': [left, right]}
+def index_expression(children):
+    return {"type": "index_expression", 'children': children}
 
 
 def key_val_pair(key_name, node):

--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -70,8 +70,8 @@ def projection(left, right):
     return {'type': 'projection', 'children': [left, right]}
 
 
-def sub_expression(left, right):
-    return {"type": "sub_expression", 'children': [left, right]}
+def sub_expression(children):
+    return {"type": "sub_expression", 'children': children}
 
 
 def value_projection(left, right):

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -185,7 +185,11 @@ class Parser(object):
     def _token_led_dot(self, left):
         if not self._current_token() == 'star':
             right = self._parse_dot_rhs(self.BINDING_POWER['dot'])
-            return ast.sub_expression(left, right)
+            if left['type'] == 'sub_expression':
+                left['children'].append(right)
+                return left
+            else:
+                return ast.sub_expression([left, right])
         else:
             # We're creating a projection.
             self._advance()

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -261,7 +261,11 @@ class Parser(object):
             self._match('number')
             right = ast.index(token['value'])
             self._match('rbracket')
-            return ast.index_expression(left, right)
+            if left['type'] == 'index_expression':
+                left['children'].append(right)
+                return left
+            else:
+                return ast.index_expression([left, right])
         else:
             # We have a projection
             self._match('star')

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -379,8 +379,10 @@ class Parser(object):
                                     token['type'], 'Invalid token')
 
     def _match(self, token_type=None):
-        if self._current_token() == token_type:
-            self._advance()
+        # inline'd self._current_token()
+        if self._tokens[self._index]['type'] == token_type:
+            # inline'd self._advance()
+            self._index += 1
         else:
             t = self._lookahead_token(0)
             lex_position = t['start']

--- a/perf/perftest.py
+++ b/perf/perftest.py
@@ -28,10 +28,13 @@ def run_tests(tests):
         lex_time = _lex_time(expression)
         parse_time = _parse_time(expression)
         search_time = _search_time(expression, given)
+        combined_time = _combined_time(expression, given)
         sys.stdout.write(
-            "lex_time: %.8f, parse_time: %.8fms, search_time: %.8fms" % (
-                1000 * lex_time, 1000 * parse_time, 1000 * search_time))
-        sys.stdout.write(" description: %s " % test['description'])
+            "lex_time: %.8f, parse_time: %.8fms, search_time: %.8fms "
+            "combined_time: %.8fms " % (1000 * lex_time,
+                                        1000 * parse_time,
+                                        1000 * search_time,
+                                        1000 * combined_time))
         sys.stdout.write("name: %s\n" % test['name'])
 
 
@@ -61,6 +64,7 @@ def _search_time(expression, given):
             best = total
     return best
 
+
 def _parse_time(expression):
     best = float('inf')
     p = Parser()
@@ -73,6 +77,21 @@ def _parse_time(expression):
         if total < best:
             best = total
     return best
+
+
+def _combined_time(expression, given):
+    best = float('inf')
+    p = Parser()
+    for i in range(DEFAULT_NUM_LOOP):
+        p.purge()
+        start = time.time()
+        p.parse(expression).search(given)
+        end = time.time()
+        total = end - start
+        if total < best:
+            best = total
+    return best
+
 
 def load_tests(filename):
     loaded = []

--- a/perf/perftest.py
+++ b/perf/perftest.py
@@ -12,6 +12,13 @@ import os
 import json
 import sys
 
+try:
+    _clock = time.process_time
+except AttributeError:
+    # Python 2.x does not have time.process_time
+    _clock = time.clock
+
+
 from jmespath.parser import Parser
 from jmespath.lexer import Lexer
 
@@ -30,63 +37,63 @@ def run_tests(tests):
         search_time = _search_time(expression, given)
         combined_time = _combined_time(expression, given)
         sys.stdout.write(
-            "lex_time: %.8f, parse_time: %.8fms, search_time: %.8fms "
-            "combined_time: %.8fms " % (1000 * lex_time,
+            "lex_time: %.5fms, parse_time: %.5fms, search_time: %.5fms "
+            "combined_time: %.5fms " % (1000 * lex_time,
                                         1000 * parse_time,
                                         1000 * search_time,
                                         1000 * combined_time))
         sys.stdout.write("name: %s\n" % test['name'])
 
 
-def _lex_time(expression):
+def _lex_time(expression, clock=_clock):
     best = float('inf')
     lex = Lexer()
     for i in range(DEFAULT_NUM_LOOP):
-        start = time.time()
+        start = clock()
         list(lex.tokenize(expression))
-        end = time.time()
+        end = clock()
         total = end - start
         if total < best:
             best = total
     return best
 
 
-def _search_time(expression, given):
+def _search_time(expression, given, clock=_clock):
     p = Parser()
     parsed = p.parse(expression)
     best = float('inf')
     for i in range(DEFAULT_NUM_LOOP):
-        start = time.time()
+        start = clock()
         parsed.search(given)
-        end = time.time()
+        end = clock()
         total = end - start
         if total < best:
             best = total
     return best
 
 
-def _parse_time(expression):
+def _parse_time(expression, clock=_clock):
     best = float('inf')
     p = Parser()
     for i in range(DEFAULT_NUM_LOOP):
         p.purge()
-        start = time.time()
+        start = clock()
         p.parse(expression)
-        end = time.time()
+        end = clock()
         total = end - start
         if total < best:
             best = total
     return best
 
 
-def _combined_time(expression, given):
+def _combined_time(expression, given, clock=_clock):
     best = float('inf')
     p = Parser()
     for i in range(DEFAULT_NUM_LOOP):
         p.purge()
-        start = time.time()
+        start = clock()
         p.parse(expression).search(given)
-        end = time.time()
+        end = clock()
         total = end - start
         if total < best:
             best = total

--- a/perf/perftest.py
+++ b/perf/perftest.py
@@ -17,7 +17,7 @@ from jmespath.lexer import Lexer
 
 
 DIRECTORY = os.path.join(os.path.dirname(os.path.abspath(__file__)))
-DEFAULT_NUM_LOOP = 100
+DEFAULT_NUM_LOOP = 1000
 
 
 def run_tests(tests):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,8 +23,9 @@ class TestParser(unittest.TestCase):
         self.assert_parsed_ast('foo', ast.field('foo'))
 
     def test_dot_syntax(self):
-        self.assert_parsed_ast('foo.bar', ast.sub_expression(ast.field('foo'),
-                                                             ast.field('bar')))
+        self.assert_parsed_ast('foo.bar',
+                               ast.sub_expression([ast.field('foo'),
+                                                   ast.field('bar')]))
 
     def test_multiple_dots(self):
         parsed = self.parser.parse('foo.bar.baz')
@@ -38,8 +39,10 @@ class TestParser(unittest.TestCase):
             'one')
 
     def test_quoted_subexpression(self):
-        self.assert_parsed_ast('"foo"."bar"', ast.sub_expression(
-            ast.field('foo'), ast.field('bar')))
+        self.assert_parsed_ast('"foo"."bar"',
+                               ast.sub_expression([
+                                   ast.field('foo'),
+                                   ast.field('bar')]))
 
     def test_wildcard(self):
         parsed = self.parser.parse('foo[*]')


### PR DESCRIPTION
Switch from a binary AST node for sub exprs and index exprs to an array of children nodes.  That is, given the expr `foo.bar.baz.qux`, we go from:

![original](https://cloud.githubusercontent.com/assets/368057/5788144/44890906-9ddb-11e4-81de-05b493b2f931.png)

To:

![after](https://cloud.githubusercontent.com/assets/368057/5788145/49729c7a-9ddb-11e4-90af-c166ab29d0db.png)


In terms of perf, we have before:

```
 python perf/perftest.py
lex_time: 0.01000ms, parse_time: 0.01900ms, search_time: 0.00500ms combined_time: 0.02500ms name: single_expression
lex_time: 0.01800ms, parse_time: 0.03400ms, search_time: 0.00800ms combined_time: 0.04400ms name: single_dot_expression
lex_time: 0.02600ms, parse_time: 0.04700ms, search_time: 0.01000ms combined_time: 0.06000ms name: double_dot_expression
lex_time: 0.03400ms, parse_time: 0.06200ms, search_time: 0.01500ms combined_time: 0.07900ms name: dot_no_match
lex_time: 0.08200ms, parse_time: 0.14700ms, search_time: 0.02500ms combined_time: 0.17400ms name: deep_nesting_10
lex_time: 0.40600ms, parse_time: 0.70600ms, search_time: 0.11300ms combined_time: 0.83500ms name: deep_nesting_50
lex_time: 0.40400ms, parse_time: 0.65900ms, search_time: 0.11300ms combined_time: 0.78800ms name: deep_nesting_50_pipe
lex_time: 0.69700ms, parse_time: 0.95500ms, search_time: 0.12100ms combined_time: 1.08900ms name: deep_nesting_50_index
lex_time: 0.05100ms, parse_time: 0.08300ms, search_time: 0.01900ms combined_time: 0.10400ms name: multi_wildcard_field
lex_time: 0.05300ms, parse_time: 0.08500ms, search_time: 0.02200ms combined_time: 0.10900ms name: wildcard_with_index
lex_time: 0.03000ms, parse_time: 0.05000ms, search_time: 0.01300ms combined_time: 0.06600ms name: wildcard_with_field_match
lex_time: 0.03100ms, parse_time: 0.05100ms, search_time: 0.01300ms combined_time: 0.06600ms name: wildcard_with_field_match2
```

After:

```
$ python perf/perftest.py
lex_time: 0.01000ms, parse_time: 0.01900ms, search_time: 0.00500ms combined_time: 0.02600ms name: single_expression
lex_time: 0.01800ms, parse_time: 0.03400ms, search_time: 0.00800ms combined_time: 0.04400ms name: single_dot_expression
lex_time: 0.02600ms, parse_time: 0.04900ms, search_time: 0.01000ms combined_time: 0.06000ms name: double_dot_expression
lex_time: 0.03300ms, parse_time: 0.06300ms, search_time: 0.01200ms combined_time: 0.07700ms name: dot_no_match
lex_time: 0.08000ms, parse_time: 0.14400ms, search_time: 0.01600ms combined_time: 0.16300ms name: deep_nesting_10
lex_time: 0.40100ms, parse_time: 0.69200ms, search_time: 0.05800ms combined_time: 0.75200ms name: deep_nesting_50
lex_time: 0.39600ms, parse_time: 0.64900ms, search_time: 0.11300ms combined_time: 0.78300ms name: deep_nesting_50_pipe
lex_time: 0.69100ms, parse_time: 0.90500ms, search_time: 0.06400ms combined_time: 0.97400ms name: deep_nesting_50_index
lex_time: 0.05100ms, parse_time: 0.08200ms, search_time: 0.01900ms combined_time: 0.10300ms name: multi_wildcard_field
lex_time: 0.05200ms, parse_time: 0.08400ms, search_time: 0.02200ms combined_time: 0.10800ms name: wildcard_with_index
lex_time: 0.03000ms, parse_time: 0.05100ms, search_time: 0.01300ms combined_time: 0.06600ms name: wildcard_with_field_match
lex_time: 0.03100ms, parse_time: 0.05100ms, search_time: 0.01300ms combined_time: 0.06500ms name: wildcard_with_field_match2
```

Note the deep_nesting_50 and the deep_nesting_50_index differences.

In addition to perf imrovements I also updated the perftest with a few changes:

* Bump up iteration count to 1000
* Use a more accurate clock when micro benchmarkin
* Add a `combined_time`, which times lexing/parsing/searching combined.

This should have no functional changes, this is purely for perf concerns.