### PR TITLE
Add AST visualization via graphviz

### DIFF
--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -436,5 +436,19 @@ class ParsedResult(object):
         result = interpreter.visit(self.parsed, value)
         return result
 
+    def _render_dot_file(self):
+        """Render the parsed AST as a dot file.
+
+        Note that this is marked as an internal method because
+        the AST is an implementation detail and is subject
+        to change.  This method can be used to help troubleshoot
+        or for development purposes, but is not considered part
+        of the public supported API.  Use at your own risk.
+
+        """
+        renderer = visitor.GraphvizVisitor()
+        contents = renderer.visit(self.parsed)
+        return contents
+
     def __repr__(self):
         return repr(self.parsed)

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -216,3 +216,27 @@ class TreeInterpreter(Visitor):
         # python and jmespath.
         return (value == '' or value == [] or value == {} or value is None or
                 value is False)
+
+
+class GraphvizVisitor(Visitor):
+    def __init__(self):
+        super(GraphvizVisitor, self).__init__()
+        self._lines = []
+        self._count = 1
+
+    def visit(self, node, *args, **kwargs):
+        self._lines.append('digraph AST {')
+        current = '%s%s' % (node['type'], self._count)
+        self._count += 1
+        self._visit(node, current)
+        self._lines.append('}')
+        return '\n'.join(self._lines)
+
+    def _visit(self, node, current):
+        self._lines.append('%s [label="%s(%s)"]' % (
+            current, node['type'], node.get('value', '')))
+        for child in node.get('children', []):
+            child_name = '%s%s' % (child['type'], self._count)
+            self._count += 1
+            self._lines.append('  %s -> %s' % (current, child_name))
+            self._visit(child, child_name)

--- a/scripts/astrender
+++ b/scripts/astrender
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+import os
+import sys
+import time
+import tempfile
+import argparse
+import shutil
+import webbrowser
+from subprocess import check_call, call, PIPE
+
+import jmespath
+import jmespath.exceptions
+
+
+def verify_preconditions():
+    # Must have a 'dot' executable on the path.
+   rc = call(['type', 'dot'], stdout=PIPE)
+   if rc != 0:
+        sys.stderr.write("Could not find the 'dot' executable.  Ensure "
+                         "that graphviz is installed.")
+        raise RuntimeError("Could not find 'dot'.")
+
+
+def main():
+    verify_preconditions()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('expression', help='JMESPath expression.')
+    parser.add_argument('-s', '--save-file',
+                        help='The filename to save the rendered AST.  If no '
+                        'value is specified, a temporary file will be used '
+                        'and immediately deleted after displaying the AST.')
+    args = parser.parse_args()
+    try:
+        parsed = jmespath.compile(args.expression)
+    except jmespath.exceptions.JMESPathError as e:
+        sys.stderr.write("Invalid expressions: %s\n" % e)
+        return 1
+    with tempfile.NamedTemporaryFile('w') as f:
+        contents = parsed._render_dot_file()
+        f.write(contents)
+        f.flush()
+        svg_name = os.path.splitext(f.name)[0] + '.png'
+        check_call('dot -Tpng %s -o %s' % (f.name, svg_name), shell=True)
+        webbrowser.open('file://%s' % svg_name)
+    # Rather than prompt the user to hit enterr
+    # just sleep for as long as we think is reasonable for
+    # an application to open and display the png.
+    time.sleep(2)
+    if args.save_file:
+        shutil.copy(svg_name, args.save_file)
+    os.remove(svg_name)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -312,5 +312,27 @@ class TestParserAddsExpressionAttribute(unittest.TestCase):
         self.assertEqual(parsed.expression, 'foo.bar')
 
 
+class TestRenderGraphvizFile(unittest.TestCase):
+    def test_dot_file_rendered(self):
+        p = parser.Parser()
+        result = p.parse('foo')
+        dot_contents = result._render_dot_file()
+        self.assertEqual(dot_contents,
+                         'digraph AST {\nfield1 [label="field(foo)"]\n}')
+
+    def test_dot_file_sub_expr(self):
+        p = parser.Parser()
+        result = p.parse('foo.bar')
+        dot_contents = result._render_dot_file()
+        self.assertEqual(
+            dot_contents,
+            'digraph AST {\n'
+            'sub_expression1 [label="sub_expression()"]\n'
+            '  sub_expression1 -> field2\n'
+            'field2 [label="field(foo)"]\n'
+            '  sub_expression1 -> field3\n'
+            'field3 [label="field(bar)"]\n}')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is an internal method for now, but it's intended to be used by anyone that needs to debug the parsed jmespath expressions.  The added `astrender` script can generate PNG files from an AST.  Here's an example output:

![original](https://cloud.githubusercontent.com/assets/368057/5788144/44890906-9ddb-11e4-81de-05b493b2f931.png)